### PR TITLE
Change warning to notice for missing configuration of cable length when port is created for the first time

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2247,7 +2247,7 @@ task_process_status BufferMgrDynamic::handlePortTable(KeyOpFieldsValuesTuple &tu
             }
             else
             {
-                SWSS_LOG_WARN("Cable length or effective speed for %s hasn't been configured yet, unable to calculate headroom", port.c_str());
+                SWSS_LOG_NOTICE("Cable length or effective speed for %s hasn't been configured yet, unable to calculate headroom", port.c_str());
                 // We don't retry here because it doesn't make sense until both cable length and speed are configured.
             }
         }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Change warning log message to notice

**Why I did it**

When system is initialized with zero ports configures and port is created without cable length, we receive this warning message, (we see it when buffer configuration is disabled)
This message is seen on each time we are adding a port.
it is Non functional issue - the port is created normally and traffic on this port works normally.

**How I verified it**

**Details if related**
